### PR TITLE
suggestion to speed up runs

### DIFF
--- a/mondrian/wdl/analyses/get_index.py
+++ b/mondrian/wdl/analyses/get_index.py
@@ -1,0 +1,30 @@
+import sys
+import argparse
+
+
+
+def get_args():
+    '''Parse input flags
+        Need to add optional task-specific input json
+    '''
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--sample-id',
+                        help='sample id.',
+                        required=True
+                        )
+    parser.add_argument('--sample-ids',
+                        help='List of sample ids.',
+                        nargs='*',
+                        required=False
+                        )
+    args_namespace = parser.parse_args()
+    return args_namespace.__dict__
+
+def main():
+    args = get_args()
+    for i, sample_id in enumerate(args['sample_ids']):
+        if sample_id == args['sample_id']:
+            sys.stdout.write(str(i))
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
At the moment the contamination marking and merge_bam_files tasks wait for insert size and coverage QC tasks in the scatter to finish. If these tasks run in a separate scatter they should run at the same time as the contamination tasks and the merge_bam_files task.